### PR TITLE
Fix license handling

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -90,6 +90,7 @@ jobs:
           echo "$LICENSE" > /tmp/oe_license.txt
           export OE_LICENSE=/tmp/oe_license.txt
           python main.py ${{ inputs.path }} $(nproc)
+          rm $OE_LICENSE
 
       - name: Commit results
         shell: bash -l {0}

--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Run benchmarks
         env:
-            LICENSE: ${{ secrets.OELICENSE }}
+            LICENSE: ${{ secrets.OE_LICENSE }}
         shell: bash -l {0}
         run: |
           set -e

--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -83,10 +83,12 @@ jobs:
 
       - name: Run benchmarks
         env:
-            OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+            LICENSE: ${{ secrets.OELICENSE }}
         shell: bash -l {0}
         run: |
           set -e
+          echo "$LICENSE" > /tmp/oe_license.txt
+          export OE_LICENSE=/tmp/oe_license.txt
           python main.py ${{ inputs.path }} $(nproc)
 
       - name: Commit results

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+oe_license.txt


### PR DESCRIPTION
Based on my [failing test run](https://github.com/openforcefield/yammbs-dataset-submission/actions/runs/10567793270), `${{ github.workspace }}` just points to the directory where the runner is running code, not to the directory of organization secrets like I thought. I took this line from [here](https://github.com/openforcefield/yammbs/blob/0a9409509ff5614e8b7c67e2b48ec376ddfc37c6/.github/workflows/ci.yaml#L31) in yammbs, but I didn't notice the second `OE_LICENSE` section [here](https://github.com/openforcefield/yammbs/blob/0a9409509ff5614e8b7c67e2b48ec376ddfc37c6/.github/workflows/ci.yaml#L61), which actually writes the `${{ secrets.OE_LICENSE }}` to a file. This PR restores my earlier `OE_LICENSE` handling (writing it to `/tmp`) and adds two further safeguards against committing the license to the repo:
1. ignoring `oe_license.txt` in the .gitignore file
2. running `rm $OE_LICENSE` before doing any git operations