### PR TITLE
Fix underscore in comment action

### DIFF
--- a/.github/workflows/opt.yaml
+++ b/.github/workflows/opt.yaml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Report dispatch to PR
         if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@v3.0.1
         with:
           pr-number: ${{ inputs.pr_number }}
           message: >
@@ -183,7 +183,7 @@ jobs:
       - name: Report status to PR
         id: reportStatusToPr
         if: always() && github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@v3.0.1
         with:
           pr-number: ${{ inputs.pr_number }}
           message: >
@@ -203,7 +203,7 @@ jobs:
 
       - name: Report status to PR on templating failure
         if: always() && steps.reportStatusToPr.outcome == 'failure'
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@v3.0.1
         with:
           pr-number: ${{ inputs.pr_number }}
           message: >

--- a/.github/workflows/opt.yaml
+++ b/.github/workflows/opt.yaml
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
         uses: thollander/actions-comment-pull-request@v3
         with:
-          pr_number: ${{ inputs.pr_number }}
+          pr-number: ${{ inputs.pr_number }}
           message: >
             A workflow has been dispatched to run the benchmarks for this PR.
 
@@ -205,7 +205,7 @@ jobs:
         if: always() && steps.reportStatusToPr.outcome == 'failure'
         uses: thollander/actions-comment-pull-request@v3
         with:
-          pr_number: ${{ inputs.pr_number }}
+          pr-number: ${{ inputs.pr_number }}
           message: >
             A workflow dispatched to run optimization benchmarks for this PR has just failed.
 

--- a/.github/workflows/torsions.yaml
+++ b/.github/workflows/torsions.yaml
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
         uses: thollander/actions-comment-pull-request@v3
         with:
-          pr_number: ${{ inputs.pr_number }}
+          pr-number: ${{ inputs.pr_number }}
           message: >
             A workflow has been dispatched to run the benchmarks for this PR.
 
@@ -192,7 +192,7 @@ jobs:
         if: always() && steps.reportStatusToPr.outcome == 'failure'
         uses: thollander/actions-comment-pull-request@v3
         with:
-          pr_number: ${{ inputs.pr_number }}
+          pr-number: ${{ inputs.pr_number }}
           message: >
             A workflow dispatched to run torsion benchmarks for this PR has just failed.
 


### PR DESCRIPTION
I think these should all be hyphens? The one in line 59 in opt.yaml prevents running optimization benchmarks at the moment, and changing to a hyphen fixes it. However, I haven't tried or tested running torsion benchmarks yet.