### PR TITLE
Pin CPU Pytorch to avoid downloading CUDA

### DIFF
--- a/devtools/env.yaml
+++ b/devtools/env.yaml
@@ -24,5 +24,9 @@ dependencies:
   # optional, GAFF only
   - openmmforcefields
 
+   # toolkit v0.17+ pulls in nagl and pytorch
+   # we want the CPU-only version of pytorch for space reasons
+  - pytorch=*=*cpu*
+
   - pip:
     - git+https://github.com/openforcefield/yammbs.git@0.2.0


### PR DESCRIPTION
This cuts the conda env into 2 GB.

This is a fix with an expiry date -- pytorch has already moved to distributing via pypi. But while NAGL pulls from conda, this is probably the best and easiest solution.