### PR TITLE
Update environment

### DIFF
--- a/devtools/env.yaml
+++ b/devtools/env.yaml
@@ -2,7 +2,6 @@ name: yammbs-dataset-submission
 
 channels:
   - conda-forge
-  - openeye
 
 dependencies:
   - python =3.12
@@ -11,7 +10,8 @@ dependencies:
   - qcportal ~=0.57
   - openff-qcsubmit
   - openff-toolkit
-  - openeye-toolkits
+  - openff-interchange >=0.5
+  - openeye::openeye-toolkits
 
   - click
   - matplotlib
@@ -25,7 +25,7 @@ dependencies:
   - panel
 
   # optional, GAFF only
-  - openmmforcefields
+  # openmmforcefields
 
    # toolkit v0.17+ pulls in nagl and pytorch
    # we want the CPU-only version of pytorch for space reasons


### PR DESCRIPTION
Closes #128
Closes #127

* `openmmforcefields` is not installed by default
* Force Interchange 0.5.x (https://github.com/openforcefield/openff-interchange/issues/1513)
* Only look in `openeye` channel for `openeye-toolkits` package