### PR TITLE
Fix OFFXML name in README for Rosemary-alpha-1c

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See [datasets/README.md](datasets/README.md)
 | [openff-2.2.0-rc1-alkanes-revert](submissions/2026-01-26-Sage-2.2.0-alkanes-revert) | openff-2.2.0-rc1-alkanes-revert.offxml | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18382916.svg)](https://doi.org/10.5281/zenodo.18382916)
 | [Sage 2.3.0 frozen alkane parameters](submissions/2026-06-04-Sage-2.3.0-alkane) | openff_unconstrained-2.3.0-frozen-alkane-params.offxml | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20563242.svg)](https://doi.org/10.5281/zenodo.20563242)
 | [Rosemary-3.0.0-alpha1b](submissions/2026-06-19-Rosemary-alpha1b) | openff_no_water_unconstrained-3.0.0-alpha1b.offxml | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20767908.svg)](https://doi.org/10.5281/zenodo.20767908)
-| [Rosemary-3.0.0-alpha1c](submissions/2026-06-19-Rosemary-alpha1c) | openff_no_water_unconstrained-3.0.0-alpha0.offxml | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20768009.svg)](https://doi.org/10.5281/zenodo.20768009)
+| [Rosemary-3.0.0-alpha1c](submissions/2026-06-19-Rosemary-alpha1c) | openff_no_water_unconstrained-3.0.0-alpha1c.offxml | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20768009.svg)](https://doi.org/10.5281/zenodo.20768009)
 
 <!-- ENDOFTABLE -->
 


### PR DESCRIPTION
Fix name of OFFXML in README for Rosemary-alpha1c, which was incorrectly listed as Rosemary-alpha0.